### PR TITLE
Experiment with Decline Queue

### DIFF
--- a/src/main/java/jobs/enqeue/TransactionSettlementProcess.java
+++ b/src/main/java/jobs/enqeue/TransactionSettlementProcess.java
@@ -3,6 +3,7 @@ package jobs.enqeue;
 import models.Transaction;
 import queue.TransactionFlow;
 import queue.TransactionFlowImpl;
+import queue.DeclineTransactionImpl;
 import util.ExcelUtil;
 
 import java.io.IOException;
@@ -12,9 +13,10 @@ import java.util.List;
 public class TransactionSettlementProcess {
     public static void main(String[] args) throws IOException {
         long count[] = new long[] {5000, 30000, 116000};
+        boolean runExperiment = false;
         for(int i = 0; i< count.length; i++){
         Instant startTime = Instant.now();
-        enqueueRecords(count[i])
+        enqueueRecords(count[i], runExperiment)
                 .processTransactions()
                 .processDeclineTransactions()
                 .displayAll();
@@ -25,10 +27,15 @@ public class TransactionSettlementProcess {
         }
     }
 
-    public static TransactionFlow enqueueRecords(long count) throws IOException {
-        List<Transaction> allTransactions = new ExcelUtil().getFromExcel();
-        TransactionFlow transactionFlow = new TransactionFlowImpl();
+    public static TransactionFlow enqueueRecords(long count, boolean runExperiment) throws IOException {
 
+        List<Transaction> allTransactions = new ExcelUtil().getFromExcel();
+        TransactionFlow transactionFlow;
+        if(runExperiment){
+            transactionFlow = new DeclineTransactionImpl();
+        } else {
+            transactionFlow = new TransactionFlowImpl();
+        }
         Instant startTime = Instant.now();
         for (int i = 0; i < count; i++) {
             transactionFlow.enqueue(allTransactions.get(i));

--- a/src/main/java/queue/DeclineTransactionImpl.java
+++ b/src/main/java/queue/DeclineTransactionImpl.java
@@ -1,0 +1,92 @@
+package queue;
+
+import models.Transaction;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class DeclineTransactionImpl implements TransactionFlow {
+    Queue<Transaction> allTransactions = new LinkedList<>();
+    //dead letter queue
+    Queue<Transaction> declinedTransactions = new LinkedList<>();
+
+    Queue<Transaction> settledTransactions = new LinkedList<>();
+
+    HashMap<String, Double> accountBalanceCheck = new HashMap<>(); //for storing account number and it's balance
+
+    // Adding transaction in the Queue from the transactions file
+    @Override
+    public void enqueue(Transaction transaction) {
+        allTransactions.offer(transaction);
+    }
+
+    // Each transaction is checked and then status of transaction is updated (Settled, Declined) according to the checks
+    @Override
+    public TransactionFlow processTransactions() {
+        Iterator iteratorForBankBalance = allTransactions.iterator();
+        while(iteratorForBankBalance.hasNext()){
+            Transaction current = (Transaction) iteratorForBankBalance.next();
+            if(!accountBalanceCheck.containsKey(current.getAccountNumber())){
+                accountBalanceCheck.put(current.getAccountNumber(), current.getBalance());
+            } 
+        }
+        Iterator iterator = allTransactions.iterator();
+        while(iterator.hasNext()){
+            Transaction current = (Transaction) iterator.next();
+            String currentAccountNumber = current.getAccountNumber();
+            Double currentBalance = accountBalanceCheck.get(currentAccountNumber);
+            if(current.getWithdrawalAmount() == 0){
+                //Deposit
+                Double currentDeposit = current.getDepositAmount();
+                Double newBalance = (currentBalance + currentDeposit);
+                accountBalanceCheck.put(currentAccountNumber, newBalance);
+                settledTransactions.add(current);
+            } else {
+                //Withdrawal
+                Double currentWithdrawal = current.getWithdrawalAmount();
+                if(currentBalance > currentWithdrawal){
+                    Double newBalance = (currentBalance - currentWithdrawal);
+                    accountBalanceCheck.put(currentAccountNumber, newBalance);
+                    settledTransactions.add(current);
+                } else {
+                    //low balance 
+                    System.out.println("Not enough Balance for transaction having ID" + current.getTransactionId());
+                    declinedTransactions.add(current);
+                }
+            }
+        }
+        return this;
+    }
+
+    // Once all the transactions are processed the 'Declined' transactions are processed again in case there is bank failure or data issue.
+    @Override
+    public TransactionFlow processDeclineTransactions() {
+        
+        System.out.println("Number of Declined Transactions before processing declined transactions = " + declinedTransactions.size());
+        Iterator iterator = declinedTransactions.iterator();
+        while(iterator.hasNext()){
+            Transaction currentTransaction = (Transaction) iterator.next();
+            Double currentWithdrawalAmount = currentTransaction.getWithdrawalAmount();
+            String currentAccountNumber = currentTransaction.getAccountNumber();
+            Double accountBalance = accountBalanceCheck.get(currentAccountNumber);
+            if (currentWithdrawalAmount < accountBalance){
+                // transactions can be processed and marked settled
+                Double newBalance = accountBalance - currentWithdrawalAmount;
+                accountBalanceCheck.put(currentAccountNumber, newBalance);
+                settledTransactions.add(currentTransaction);
+                iterator.remove();
+            }
+        }
+        System.out.println("Number of Declined Transactions after processing declined transactions = " + declinedTransactions.size());
+        return this;
+    }
+
+    // All the 'Settled' transactions are displayed.
+    @Override
+    public void displayAll() {
+        }
+    }
+

--- a/src/main/java/queue/TransactionFlowImpl.java
+++ b/src/main/java/queue/TransactionFlowImpl.java
@@ -3,7 +3,6 @@ package queue;
 import models.Transaction;
 
 import java.time.Instant;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;
 


### PR DESCRIPTION
Created HashMap to store account number & account balance Used queue to manage declined transactions
Updated account balance with deposit amt & valid withdrawal transactions Declined withdrawal transactions based on account balance Prints the size of decline queue before processing the declined transaction queue Prints the reduced size of the declined transactions upon reprocessing the declined transaction queue Added a feature flag to toggle between experiments